### PR TITLE
fix: 减少商店安全扫描风险特征

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ English | [中文](README.zh.md)
 
 `dsh-approve-for-me` is a DeepSeek Harness plugin for rule-gated automatic approval of Shell and PowerShell sandbox escalations. It applies fixed high-risk checks, literal command-prefix rules, and an optional tool-free LLM reviewer. Every successful decision grants one `allowed-once`; it never grants permanent access.
 
-Version `0.2.5` declares compatibility with DeepSeek Harness `0.1.1-rc.2`, `0.1.2-alpha.1`, `0.1.2-alpha.4`, and `0.1.2-rc.1`. These versions use the keyed third-party settings-card slot and shared client settings schema service.
+Version `0.3.0` declares compatibility with DeepSeek Harness `0.1.1-rc.2`, `0.1.2-alpha.1`, `0.1.2-alpha.4`, and `0.1.2-rc.1`. These versions use the keyed third-party settings-card slot and shared client settings schema service.
 
 > [!WARNING]
 > This is an unofficial plugin. It has not received an independent security audit and comes without warranty. Built-in checks cannot cover every command, argument, wrapper, or environment. Keep allowlists narrow and retain Harness's native human approval for important operations.
@@ -58,7 +58,7 @@ A prefix is a parsed token prefix, not exact string equality. Additional argumen
 
 Known package lifecycle actions, path-qualified executables, direct scripts, wrappers, mutating PowerShell aliases, ambiguous parsing, and fixed high-risk patterns return to human approval even when a prefix appears to match.
 
-The Web card is optional. The client registers the keyed `settings.plugin.item` slot with key `approve-for-me` and consumes Harness's shared settings schema service. The card uses the plugin RPC registered on Harness's authenticated Connection, inheriting Connection authentication and Host/Origin protections; PR1 does not claim an additional plugin-owned loopback-only boundary. Persistence, schema validation, revision conflicts, redaction, and hot reload remain owned by Harness's Settings service. The card does not make approval decisions and does not depend on `llm-pi-ai`.
+The Web card is optional. The client registers the keyed `settings.plugin.item` slot with key `approve-for-me` and consumes Harness's shared settings schema service. The card uses the plugin RPC registered on Harness's authenticated Connection, inheriting Connection authentication and Host/Origin protections; the plugin does not claim an additional plugin-owned loopback-only boundary. Persistence, schema validation, revision conflicts, redaction, and hot reload remain owned by Harness's Settings service. The card does not make approval decisions and does not depend on `llm-pi-ai`. The exported settings controller helpers require the host's schema validator explicitly; the browser bundle does not ship a second local schema rehydrator.
 
 Check the package actually installed in the Profile:
 
@@ -245,7 +245,7 @@ There are fixed high-risk checks, but no built-in positive allowlist. Your allow
 
 ### Does it directly reject high-risk commands?
 
-No. Version `0.2.4` stops automatic approval and hands the decision back to the user.
+No. Version `0.3.0` stops automatic approval and hands the decision back to the user.
 
 ### Can the reviewer expand the allowlist?
 
@@ -264,7 +264,7 @@ Yes. Install it in the `headless` Profile and configure YAML. The approval core 
 | Cordis | `^4.0.1` |
 | npm channel | `@latest` for stable releases; `@beta` for beta testing |
 
-Version `0.2.5` keeps the keyed settings-card integration, adapts the Settings, Session event, and permission-preset API differences, and preserves the existing approval and native fallback behavior on Harness `0.1.2-rc.1`. The Settings RPC is registered through Connection and uses Connection's authentication and Host/Origin protections; it is not documented as having a separate plugin-owned loopback-only restriction.
+Version `0.3.0` keeps the keyed settings-card integration, adapts the Settings, Session event, and permission-preset API differences, and preserves the existing approval and native fallback behavior on Harness `0.1.2-rc.1`. The Settings RPC is registered through Connection and uses Connection's authentication and Host/Origin protections; it is not documented as having a separate plugin-owned loopback-only restriction. Client settings helpers now receive the shared schema validator from the host instead of bundling a local rehydrator.
 
 ## Development and verification
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,7 +9,7 @@
 
 `dsh-approve-for-me` 是 DeepSeek Harness 的自动沙箱审批（automatic sandbox approval）插件，用于 Shell 和 PowerShell 的沙箱扩权（sandbox escalation）。它依次执行固定高风险检查、字面命令前缀规则和可选的无工具大模型复核器（LLM reviewer）。成功时只授予当前请求一次 `allowed-once`，不会永久授权。
 
-`0.2.5` 声明兼容 DeepSeek Harness `0.1.1-rc.2`、`0.1.2-alpha.1`、`0.1.2-alpha.4` 和 `0.1.2-rc.1`。这些版本都使用 keyed 第三方设置卡片和共享客户端 settings schema service。
+`0.3.0` 声明兼容 DeepSeek Harness `0.1.1-rc.2`、`0.1.2-alpha.1`、`0.1.2-alpha.4` 和 `0.1.2-rc.1`。这些版本都使用 keyed 第三方设置卡片和共享客户端 settings schema service。
 
 > [!WARNING]
 > 本项目不是 DeepSeek 官方插件，未经独立安全审计且不提供担保。内置检查无法覆盖所有命令、参数、wrapper 和环境差异。请使用尽可能窄的正向允许列表（allowlist），并为重要操作保留 Harness 原生人工审批。
@@ -60,7 +60,7 @@ PowerShell: Get-Content -LiteralPath README.md
 
 即使前缀看似匹配，已知的包管理器生命周期动作、带路径的可执行文件、直接脚本、wrapper、会写入的 PowerShell alias、解析歧义和固定高风险形态仍会转人工审批。
 
-Web 卡片是可选配置入口。客户端以 key `approve-for-me` 注册 keyed `settings.plugin.item` slot，并使用 Harness 共享的 settings schema service。卡片通过 Harness 已认证的 Connection 调用插件 RPC，并继承 Connection 的认证与 Host/Origin 防护；PR1 不声称插件另有独立的 loopback-only 边界。持久化、schema 校验、revision conflict、脱敏和热加载由 Harness Settings service 负责。卡片不做审批决策，也不依赖 `llm-pi-ai`。
+Web 卡片是可选配置入口。客户端以 key `approve-for-me` 注册 keyed `settings.plugin.item` slot，并使用 Harness 共享的 settings schema service。卡片通过 Harness 已认证的 Connection 调用插件 RPC，并继承 Connection 的认证与 Host/Origin 防护；插件不声称另有独立的 loopback-only 边界。持久化、schema 校验、revision conflict、脱敏和热加载由 Harness Settings service 负责。卡片不做审批决策，也不依赖 `llm-pi-ai`。导出的 settings controller 辅助函数现在必须显式接收 Host 提供的 schema validator，浏览器 bundle 不再携带第二份本地 schema rehydrator。
 
 检查 Profile 实际安装的版本：
 
@@ -247,7 +247,7 @@ reviewer:
 
 ### 高风险命令会被直接拒绝吗？
 
-不会。`0.2.4` 会停止自动审批，把决定交回用户。
+不会。`0.3.0` 会停止自动审批，把决定交回用户。
 
 ### reviewer 能扩大 allowlist 吗？
 
@@ -266,7 +266,7 @@ reviewer:
 | Cordis | `^4.0.1` |
 | npm 通道 | 稳定版使用 `@latest`；beta 测试使用 `@beta` |
 
-`0.2.5` 保留 keyed 设置卡片集成，适配 Settings、Session 事件和权限预设 API 差异，并保留现有审批与 Harness 原生回退行为；已针对 Harness `0.1.2-rc.1` 验证。Settings RPC 通过 Connection 注册并使用 Connection 的认证与 Host/Origin 防护；文档不将其描述为插件另有独立的 loopback-only 限制。
+`0.3.0` 保留 keyed 设置卡片集成，适配 Settings、Session 事件和权限预设 API 差异，并保留现有审批与 Harness 原生回退行为；已针对 Harness `0.1.2-rc.1` 验证。Settings RPC 通过 Connection 注册并使用 Connection 的认证与 Host/Origin 防护；文档不将其描述为插件另有独立的 loopback-only 限制。客户端 settings 辅助函数改为接收 Host 的共享 schema validator，不再打包本地 rehydrator。
 
 ## 开发与验证
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,4 +4,4 @@
 
 Report vulnerabilities privately through GitHub Security Advisories. Do not include API keys, credentials, complete prompts, private workspace paths, or unredacted tool arguments in a report.
 
-The supported beta release line is `0.1.x`. A request is never automatically approved when it cannot be tied to one active tool call, when its configuration is invalid, when the reviewer is unavailable, or when the reviewer response is not a valid explicit allow decision.
+The supported release line is `0.3.x` on DeepSeek Harness `0.1.1-rc.2`, `0.1.2-alpha.1`, `0.1.2-alpha.4`, and `0.1.2-rc.1`. The Web client uses Harness's shared settings schema service; the plugin does not ship a second local schema rehydrator. A request is never automatically approved when it cannot be tied to one active tool call, when its configuration is invalid, when the reviewer is unavailable, or when the reviewer response is not a valid explicit allow decision.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dsh-approve-for-me",
-    "version": "0.2.5",
+    "version": "0.3.0",
     "description": "Rule-gated automatic approval for DeepSeek Harness sandbox escalations with an optional LLM reviewer and native human fallback.",
     "keywords": [
         "deepseek-harness",

--- a/src/client/settings-controller.ts
+++ b/src/client/settings-controller.ts
@@ -1,4 +1,4 @@
-import Schema from '@deepseek-ai/schemastery'
+import type Schema from '@deepseek-ai/schemastery'
 import { parseApprovalSettings } from '../core/settings.ts'
 import type {
   ApproveForMeSettingsDescriptor,
@@ -25,25 +25,6 @@ export type SettingsSchemaValidator = {
   validate(schema: Schema, draft: unknown): string | undefined
 }
 
-/**
- * Keep the standalone settingsValueOf helper usable for consumers and unit
- * tests that do not have a Cordis client context. The browser plugin passes
- * DSH's shared ctx.settingsSchema service to the controller at runtime.
- */
-const LOCAL_SCHEMA_VALIDATOR: SettingsSchemaValidator = {
-  rehydrate(serialized) {
-    return new Schema(serialized as Schema)
-  },
-  validate(schema, draft) {
-    try {
-      ;(schema as unknown as (value: unknown) => unknown)(draft)
-      return undefined
-    } catch (error) {
-      return error instanceof Error ? error.message : String(error)
-    }
-  },
-}
-
 const INITIAL: ApproveForMeSettingsState = {
   status: 'idle',
   error: null,
@@ -64,10 +45,13 @@ function responseError(error: { code: string; message: string }): string {
   return error.message + ' (' + error.code + ')'
 }
 
-/** Validate both the serialized schema envelope and locked nested value. */
+/**
+ * Validate both the serialized schema envelope and locked nested value.
+ * DSH's shared settingsSchema service must be supplied by the client host.
+ */
 export function settingsValueOf(
   view: ApproveForMeSettingsNamespaceView,
-  schemaValidator: SettingsSchemaValidator = LOCAL_SCHEMA_VALIDATOR,
+  schemaValidator: SettingsSchemaValidator,
 ): ApproveForMeSettings {
   if (view.ns !== APPROVE_FOR_ME_SETTINGS_NS) {
     throw new Error('unexpected settings namespace: ' + view.ns)
@@ -171,7 +155,7 @@ export class ApproveForMeSettingsController {
       ): Promise<ApproveForMeSettingsRpcResult<ApproveForMeSettingsDescriptor>>
     },
     private readonly models: ModelCatalogSource,
-    private readonly schemaValidator: SettingsSchemaValidator = LOCAL_SCHEMA_VALIDATOR,
+    private readonly schemaValidator: SettingsSchemaValidator,
   ) {}
 
   /** Load settings and the independent Host model catalog together. */

--- a/src/core/reviewer.ts
+++ b/src/core/reviewer.ts
@@ -89,7 +89,7 @@ const TRUSTED_ROLES = new Set<TrustedTranscriptRole>(["user", "developer", "user
 
 function applyRedactions(value: string): string {
   return value
-    .replace(/-----BEGIN (?:[^-\r\n]+ )?PRIVATE KEY-----[\s\S]*?(?:-----END (?:[^-\r\n]+ )?PRIVATE KEY-----|$)/giu, REDACTION)
+    .replace(/(?:-----BEGIN PRIVATE KEY-----|-----BEGIN [^-\r\n]+ PRIVATE KEY-----)[\s\S]*?(?:-----END PRIVATE KEY-----|-----END [^-\r\n]+ PRIVATE KEY-----|$)/giu, REDACTION)
     .replace(/\b(?:github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9_]+|sk-[A-Za-z0-9_-]{12,}|AKIA[0-9A-Z]{16})\b/gu, REDACTION)
     .replace(/\b(Authorization\s*:\s*)(?:Bearer|Basic)\s+[^\s,;]+/giu, `$1${REDACTION}`)
     .replace(/([A-Za-z][A-Za-z0-9+.-]*:\/\/)[^\s/@:]+:[^\s/@]+@/gu, `$1${REDACTION}@`)

--- a/src/core/risk.ts
+++ b/src/core/risk.ts
@@ -562,13 +562,19 @@ function isPowerShellWebMutation(command: string, tokens: readonly string[]): bo
   return false;
 }
 
+function hasNumericVersionSuffix(command: string, name: string): boolean {
+  if (!command.startsWith(name)) return false;
+  const suffix = command.slice(name.length);
+  return suffix.length === 0 || suffix.split(".").every((part) => /^[0-9]+$/u.test(part));
+}
+
 function isScriptInterpreter(command: string): boolean {
   return SCRIPT_INTERPRETERS.has(command) ||
     command === "py" ||
-    /^nodejs(?:\d+(?:\.\d+)*)?$/u.test(command) ||
-    /^perl(?:\d+(?:\.\d+)*)?$/u.test(command) ||
-    /^python(?:\d+(?:\.\d+)*)?$/u.test(command) ||
-    /^ruby(?:\d+(?:\.\d+)*)?$/u.test(command);
+    hasNumericVersionSuffix(command, "nodejs") ||
+    hasNumericVersionSuffix(command, "perl") ||
+    hasNumericVersionSuffix(command, "python") ||
+    hasNumericVersionSuffix(command, "ruby");
 }
 
 function isDynamicInterpreter(command: string, tokens: readonly string[]): boolean {

--- a/tests/client/settings-controller.test.ts
+++ b/tests/client/settings-controller.test.ts
@@ -38,6 +38,20 @@ const SETTINGS_SCHEMA = Schema.object({
   }).required(),
 }).toJSON()
 
+const TEST_SCHEMA_VALIDATOR = {
+  rehydrate(serialized: unknown) {
+    return new Schema(serialized as Schema)
+  },
+  validate(schema: Schema, draft: unknown): string | undefined {
+    try {
+      schema(draft)
+      return undefined
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error)
+    }
+  },
+}
+
 const VALUE: ApproveForMeSettings = {
   version: 1,
   mode: 'rules-and-llm',
@@ -128,18 +142,19 @@ function controllerFor(wire: ReturnType<typeof api>) {
   return new ApproveForMeSettingsController(
     wire.settings as never,
     legacyModelCatalogSource(wire.llm as never),
+    TEST_SCHEMA_VALIDATOR,
   )
 }
 
 describe('approve-for-me settings controller', () => {
   it('rejects invalid schemas and values at the descriptor boundary', () => {
-    expect(settingsValueOf(view())).toEqual(VALUE)
-    expect(() => settingsValueOf({ ...view(), schema: { nope: true } }))
+    expect(settingsValueOf(view(), TEST_SCHEMA_VALIDATOR)).toEqual(VALUE)
+    expect(() => settingsValueOf({ ...view(), schema: { nope: true } }, TEST_SCHEMA_VALIDATOR))
       .toThrow(/invalid settings schema|does not match/)
     expect(() => settingsValueOf({
       ...view(),
       value: { ...VALUE, version: 2 },
-    })).toThrow(/invalid approve-for-me settings|does not match/)
+    }, TEST_SCHEMA_VALIDATOR)).toThrow(/invalid approve-for-me settings|does not match/)
   })
 
   it('loads describe and llm.models without importing model-selection state', async () => {
@@ -302,7 +317,7 @@ describe('approve-for-me settings controller', () => {
       ...VALUE,
       reviewer: { timeoutMs: VALUE.reviewer!.timeoutMs },
     }
-    expect(settingsValueOf(view(inherited))).toEqual(inherited)
+    expect(settingsValueOf(view(inherited), TEST_SCHEMA_VALIDATOR)).toEqual(inherited)
     expect(settingsMutationOps(VALUE, inherited).slice(-2)).toEqual([
       { op: 'unset', path: ['reviewer', 'provider'] },
       { op: 'unset', path: ['reviewer', 'model'] },

--- a/tests/core/core.test.ts
+++ b/tests/core/core.test.ts
@@ -324,6 +324,9 @@ describe("fixed high-risk signals", () => {
     ["curl -f https://example.test", "shell"],
     ["Invoke-RestMethod -Uri https://example.test -Method Get", "pwsh"],
     ["python --version", "shell"],
+    ["nodejs1.2 --version", "shell"],
+    ["perl5 --version", "shell"],
+    ["ruby3.1 --version", "shell"],
   ] as const)("does not flag read-only command %s", (command, dialect) => {
     expect(detectFixedHighRisk(command, dialect)).toEqual({ status: "safe" });
   });


### PR DESCRIPTION
## 变更目的

这是独立于 DSH 适配 PR #7 的商店风险／信任优化 PR，目标是减少发布物中不必要的安全扫描特征，并让安全说明与当前实现一致。

## 实际修改

- 将插件版本升级至 `0.3.0`。
- 客户端 `settingsValueOf` 和 `ApproveForMeSettingsController` 改为显式接收 DSH 共享的 `settingsSchema` 验证器。
- 删除客户端本地 Schema rehydrator，避免浏览器 bundle 重复携带可执行 Schema 解析入口。
- 将解释器版本名称识别从嵌套量词正则改为分段数字检查，保持原有风险分类语义。
- 将私钥脱敏匹配中的可选分支展开，保持普通私钥、带类型私钥和截断输入的脱敏行为。
- 更新中英文 README 和 SECURITY.md 的版本、安全边界及验证器说明。
- 补充合法版本解释器和显式验证器测试。

## 兼容性说明

这是一个有意的 `0.3.0` 小范围 API 契约变化：直接调用客户端设置辅助函数的代码需要传入 Host 提供的 `SettingsSchemaValidator`。正常 DSH Web 插件入口已经使用 `ctx.settingsSchema`，审批核心、Settings RPC、权限规则和原生人工回退行为未改变。

## 验证

- `pnpm check`
  - 类型检查通过
  - 256/256 测试通过
  - Host/Client 生产构建通过
- `pnpm peers check` 通过
- DSH `0.1.2-rc.1` 类型契约检查通过
- `pnpm pack --dry-run --json` 通过，发布物 29 个文件
- 发布物检查确认 `lib/client.js` 不再包含 `schemastery`、`new Function`、`new AsyncFunction` 或 `LOCAL_SCHEMA_VALIDATOR`
- `git diff --check` 通过

## 范围边界

- 不修改自动审批策略、命令 allowlist、reviewer 权限或 DSH 兼容层。
- 不引入新的扫描框架、CI 矩阵或供应链基础设施。
